### PR TITLE
Ensure find command available in RHEL-based

### DIFF
--- a/bootstrap-salt.sh
+++ b/bootstrap-salt.sh
@@ -4808,7 +4808,7 @@ install_centos_stable_deps() {
         fi
     fi
 
-    __PACKAGES="${__PACKAGES} procps"
+    __PACKAGES="${__PACKAGES} procps findutils"
 
     # shellcheck disable=SC2086
     __yum_install_noinput ${__PACKAGES} || return 1
@@ -5108,7 +5108,7 @@ install_centos_onedir_deps() {
         __PACKAGES="yum-utils chkconfig"
     fi
 
-    __PACKAGES="${__PACKAGES} procps"
+    __PACKAGES="${__PACKAGES} procps findutils"
 
     # shellcheck disable=SC2086
     __yum_install_noinput ${__PACKAGES} || return 1


### PR DESCRIPTION
The Rocky Linux 8 container doesn't ship the package `findutils`. The missing find command resulted in failed installs for salt 3006

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant
